### PR TITLE
UICIRCLOG-77 use compatible plugin-find-user version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (IN PROGRESS)
 
+* [UICIRCLOG-77](https://issues.folio.org/browse/UICIRCLOG-77) `plugin-find-user` is now compatible with `stripes` `v7`.
+
 ## [2.0.0](https://github.com/folio-org/ui-circulation-log/tree/v2.0.0) (2021-10-06)
 [Full Changelog](https://github.com/folio-org/ui-circulation-log/compare/v1.2.0...v2.0.0)
 * [UICIRCLOG-70](https://issues.folio.org/browse/UICIRCLOG-70) Add support for log records with new Circ action: "Send error".

--- a/package.json
+++ b/package.json
@@ -118,6 +118,6 @@
     "react-router-dom": "^5.2.0"
   },
   "optionalDependencies": {
-    "@folio/plugin-find-user": "^5.0.0"
+    "@folio/plugin-find-user": "^6.0.0"
   }
 }


### PR DESCRIPTION
The optional dependency `@folio/plugin-find-user` must be compatible
with the peer-dependency on `@folio/stripes`, `v7.0.0`.

@vashjs, @uladislausamets: I don't have commit permission on this repository so I'm tagging you here since I can't add PR reviewers. Can you please merge this if it looks OK to you? 

Refs [UICIRCLOG-77](https://issues.folio.org/browse/UICIRCLOG-77)
