### PR TITLE
UICIRCLOG-122 Make patron and staff information visible in circulation log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## (IN PROGRESS)
 * [UICIRCLOG-115](https://issues.folio.org/browse/UICIRCLOG-115) Implement EXACT search for item barcode in circulation log
+* [UICIRCLOG-122](https://issues.folio.org/browse/UICIRCLOG-122) Make patron and staff information visible and searchable in Circulation log
 
 ## [3.0.0](https://github.com/folio-org/ui-circulation-log/tree/v3.0.0) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-circulation-log/compare/v2.3.0...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "@babel/eslint-parser": "^7.18.2",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-decorators": "^7.0.0",
+    "@babel/plugin-proposal-private-methods": "^7.18.0",
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.0",
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.7.4",

--- a/translations/ui-circulation-log/en.json
+++ b/translations/ui-circulation-log/en.json
@@ -68,6 +68,8 @@
   "logEvent.action.Waived partially": "Waived partially",
   "logEvent.action.Created through override": "Created through override",
   "logEvent.action.Send error": "Send error",
+  "logEvent.action.Patron info added": "Patron info added",
+  "logEvent.action.Staff info added": "Staff info added",
 
   "logEvent.actions.itemDetails": "Item details",
   "logEvent.actions.userDetails": "User details",


### PR DESCRIPTION
All the real work was done in mod-circulation (and a little in mod-audit): all that was needed here was the addition of some translations for the new actions.

Fixes UICIRCLOG-122.