### PR TITLE
UICIRCLOG-128 Mark old patron info as superseded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [UICIRCLOG-115](https://issues.folio.org/browse/UICIRCLOG-115) Implement EXACT search for item barcode in circulation log
 * [UICIRCLOG-122](https://issues.folio.org/browse/UICIRCLOG-122) Make patron and staff information visible and searchable in Circulation log
 * [UICIRCLOG-123](https://issues.folio.org/browse/UICIRCLOG-123) Add loan patron and staff info filter to circulation log.
+* [UICIRCLOG-128](https://issues.folio.org/browse/UICIRCLOG-128) Distinct between patron info and patron info (SUPERSEDED) in the Circ action column
 
 ## [3.0.0](https://github.com/folio-org/ui-circulation-log/tree/v3.0.0) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-circulation-log/compare/v2.3.0...v3.0.0)

--- a/src/CirculationLogList/CirculationLogList.js
+++ b/src/CirculationLogList/CirculationLogList.js
@@ -34,6 +34,7 @@ import { CirculationLogListFilter } from './CirculationLogListFilter';
 import { CirculationLogListActions } from './CirculationLogListActions';
 import { CirculationLogEventActions } from './CirculationLogEventActions';
 import { FormattedTime } from './FormattedTime';
+import markOldPatronInfoAsSuperseded from './markOldPatronInfoAsSuperseded';
 
 const resultsPaneTitle = <FormattedMessage id="ui-circulation-log.meta.title" />;
 const sortableFields = ['userBarcode', 'itemBarcode', 'object', 'action', 'date', 'source', 'description'];
@@ -176,7 +177,7 @@ export const CirculationLogList = ({
             <MultiColumnList
               id="circulation-log-list"
               totalCount={logEventsCount}
-              contentData={logEvents}
+              contentData={markOldPatronInfoAsSuperseded(logEvents)}
               visibleColumns={visibleColumns}
               columnMapping={columnMapping}
               formatter={resultsFormatter}

--- a/src/CirculationLogList/CirculationLogList.js
+++ b/src/CirculationLogList/CirculationLogList.js
@@ -34,7 +34,7 @@ import { CirculationLogListFilter } from './CirculationLogListFilter';
 import { CirculationLogListActions } from './CirculationLogListActions';
 import { CirculationLogEventActions } from './CirculationLogEventActions';
 import { FormattedTime } from './FormattedTime';
-import markOldPatronInfoAsSuperseded from './markOldPatronInfoAsSuperseded';
+import { markOldPatronInfoAsSuperseded } from './markOldPatronInfoAsSuperseded';
 
 const resultsPaneTitle = <FormattedMessage id="ui-circulation-log.meta.title" />;
 const sortableFields = ['userBarcode', 'itemBarcode', 'object', 'action', 'date', 'source', 'description'];

--- a/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
+++ b/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
@@ -74,4 +74,4 @@ function markOldPatronInfoAsSuperseded(list) {
   });
 }
 
-export default markOldPatronInfoAsSuperseded;
+export { markOldPatronInfoAsSuperseded };

--- a/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
+++ b/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
@@ -52,7 +52,8 @@ function registerMostRecentPatronNotes(list) {
 function markOldPatronInfoAsSuperseded(list) {
   // console.log(list);
 
-  const chronologicalList = list.toSorted((a, b) => (
+  const chronologicalList = [...list];
+  chronologicalList.sort((a, b) => (
     a.date < b.date ? 1 :
       a.date > b.date ? -1 :
         0

--- a/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
+++ b/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
@@ -1,7 +1,3 @@
-// This looks like human-readable text, but is really an opaque ID
-// XXX can it be included from elsewhere in the source?
-const PATRON_INFO_ADDED = 'Patron info added';
-
 /*
    In the markOldPatronInfoAsSuperseded function, we want to mark
    superseded patron-info events (i.e. all such events but the last
@@ -19,6 +15,8 @@ const PATRON_INFO_ADDED = 'Patron info added';
    and changing the relevant entries.
 */
 
+import { LOAN_ACTIONS } from './constants';
+
 // PRIVATE
 function record2itemId(rec) {
   // Not every record has an item; potentially some have more than one
@@ -31,7 +29,7 @@ function registerMostRecentPatronNotes(list) {
   const itemBarcode2mostRecentPatronNote = {};
 
   list.forEach(rec => {
-    if (rec.action === PATRON_INFO_ADDED) {
+    if (rec.action === LOAN_ACTIONS.PATRON_INFO) {
       const itemId = record2itemId(rec);
 
       if (!itemId) {
@@ -68,7 +66,7 @@ function markOldPatronInfoAsSuperseded(list) {
     const itemId = record2itemId(rec);
     const newRec = { ...rec };
 
-    if (rec.action === PATRON_INFO_ADDED && itemBarcode2mostRecentPatronNote[itemId] !== rec.id) {
+    if (rec.action === LOAN_ACTIONS.PATRON_INFO && itemBarcode2mostRecentPatronNote[itemId] !== rec.id) {
       newRec.action = 'Patron info superseded';
     }
 

--- a/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
+++ b/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
@@ -53,6 +53,7 @@ function markOldPatronInfoAsSuperseded(list) {
   // console.log(list);
 
   const chronologicalList = [...list];
+
   chronologicalList.sort((a, b) => (
     a.date < b.date ? 1 :
       a.date > b.date ? -1 :

--- a/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
+++ b/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
@@ -75,4 +75,4 @@ function markOldPatronInfoAsSuperseded(list) {
   });
 }
 
-export { markOldPatronInfoAsSuperseded };
+export { registerMostRecentPatronNotes, markOldPatronInfoAsSuperseded };

--- a/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
+++ b/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
@@ -1,0 +1,70 @@
+// This looks like human-readable text, but is really an opaque ID
+// XXX can it be included from elsewhere in the source?
+const PATRON_INFO_ADDED = 'Patron info added';
+
+/*
+   In the markOldPatronInfoAsSuperseded function, we want to mark
+   superseded patron-info events (i.e. all such events but the last
+   for each item).
+
+   We effect this change visually by changing the their `action` field
+   from "Patron info added" to "Patron info superseded".
+
+   Identifying the relevant records is tricky in the general case,
+   though, as the list may not be sorted chronologically. (It starts
+   out that way, but the user can re-sort the list by clicking on a
+   column header). So we have to go the long way around, generating
+   chronologically sorted list, using this to generate a register of
+   entries that need changing, then running through the original list
+   and changing the relevant entries.
+*/
+
+// PRIVATE
+function registerMostRecentPatronNotes(list) {
+  const itemBarcode2mostRecentPatronNote = {};
+
+  list.forEach(rec => {
+    if (rec.action === PATRON_INFO_ADDED) {
+      const itemId = rec.items[0]?.itemBarcode;
+
+      if (!itemId) {
+        // console.log('no itemId in', rec);
+      } else if (!itemBarcode2mostRecentPatronNote[itemId]) {
+        // console.log('first patron-info for item', itemId, 'is', rec.id);
+        itemBarcode2mostRecentPatronNote[itemId] = rec.id;
+      } else {
+        // console.log(' ignoring spare patron-info for item', itemId, '-', rec.id);
+      }
+    }
+  });
+
+  return itemBarcode2mostRecentPatronNote;
+}
+
+
+function markOldPatronInfoAsSuperseded(list) {
+  // console.log(list);
+
+  const chronologicalList = list.toSorted((a, b) => (
+    a.date < b.date ? 1 :
+      a.date > b.date ? -1 :
+        0
+  ));
+
+  const itemBarcode2mostRecentPatronNote = registerMostRecentPatronNotes(chronologicalList);
+
+  // console.log(itemBarcode2mostRecentPatronNote);
+
+  return list.map(rec => {
+    const itemId = rec.items[0]?.itemBarcode;
+    const newRec = { ...rec };
+
+    if (rec.action === PATRON_INFO_ADDED && itemBarcode2mostRecentPatronNote[itemId] !== rec.id) {
+      newRec.action = 'Patron info superseded';
+    }
+
+    return newRec;
+  });
+}
+
+export default markOldPatronInfoAsSuperseded;

--- a/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
+++ b/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
@@ -32,13 +32,8 @@ function registerMostRecentPatronNotes(list) {
     if (rec.action === LOAN_ACTIONS.PATRON_INFO) {
       const itemId = record2itemId(rec);
 
-      if (!itemId) {
-        // console.log('no itemId in', rec);
-      } else if (!itemBarcode2mostRecentPatronNote[itemId]) {
-        // console.log('first patron-info for item', itemId, 'is', rec.id);
+      if (itemId && !itemBarcode2mostRecentPatronNote[itemId]) {
         itemBarcode2mostRecentPatronNote[itemId] = rec.id;
-      } else {
-        // console.log(' ignoring spare patron-info for item', itemId, '-', rec.id);
       }
     }
   });
@@ -48,8 +43,6 @@ function registerMostRecentPatronNotes(list) {
 
 
 function markOldPatronInfoAsSuperseded(list) {
-  // console.log(list);
-
   const chronologicalList = [...list];
 
   chronologicalList.sort((a, b) => (
@@ -59,8 +52,6 @@ function markOldPatronInfoAsSuperseded(list) {
   ));
 
   const itemBarcode2mostRecentPatronNote = registerMostRecentPatronNotes(chronologicalList);
-
-  // console.log(itemBarcode2mostRecentPatronNote);
 
   return list.map(rec => {
     const itemId = record2itemId(rec);

--- a/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
+++ b/src/CirculationLogList/markOldPatronInfoAsSuperseded.js
@@ -20,12 +20,19 @@ const PATRON_INFO_ADDED = 'Patron info added';
 */
 
 // PRIVATE
+function record2itemId(rec) {
+  // Not every record has an item; potentially some have more than one
+  return rec.items?.[0]?.itemBarcode;
+}
+
+
+// PRIVATE
 function registerMostRecentPatronNotes(list) {
   const itemBarcode2mostRecentPatronNote = {};
 
   list.forEach(rec => {
     if (rec.action === PATRON_INFO_ADDED) {
-      const itemId = rec.items[0]?.itemBarcode;
+      const itemId = record2itemId(rec);
 
       if (!itemId) {
         // console.log('no itemId in', rec);
@@ -56,7 +63,7 @@ function markOldPatronInfoAsSuperseded(list) {
   // console.log(itemBarcode2mostRecentPatronNote);
 
   return list.map(rec => {
-    const itemId = rec.items[0]?.itemBarcode;
+    const itemId = record2itemId(rec);
     const newRec = { ...rec };
 
     if (rec.action === PATRON_INFO_ADDED && itemBarcode2mostRecentPatronNote[itemId] !== rec.id) {

--- a/src/CirculationLogList/markOldPatronInfoAsSuperseded.test.js
+++ b/src/CirculationLogList/markOldPatronInfoAsSuperseded.test.js
@@ -1,12 +1,13 @@
 import '@folio/stripes-acq-components/test/jest/__mock__';
 import { registerMostRecentPatronNotes, markOldPatronInfoAsSuperseded } from './markOldPatronInfoAsSuperseded';
+import { LOAN_ACTIONS } from './constants';
 
 const data = [
-  { id: 1, items: [{ itemBarcode: 123 }], action: 'Patron info added' },
-  { id: 2, items: [{ itemBarcode: 123 }], action: 'Patron info added' },
-  { id: 3, items: [{ itemBarcode: 234 }], action: 'Patron info added' },
-  { id: 4, items: [{ itemBarcode: 123 }], action: 'Patron info added' },
-  { id: 5, items: [{ itemBarcode: 234 }], action: 'Patron info added' },
+  { id: 1, items: [{ itemBarcode: 123 }], action: LOAN_ACTIONS.PATRON_INFO },
+  { id: 2, items: [{ itemBarcode: 123 }], action: LOAN_ACTIONS.PATRON_INFO },
+  { id: 3, items: [{ itemBarcode: 234 }], action: LOAN_ACTIONS.PATRON_INFO },
+  { id: 4, items: [{ itemBarcode: 123 }], action: LOAN_ACTIONS.PATRON_INFO },
+  { id: 5, items: [{ itemBarcode: 234 }], action: LOAN_ACTIONS.PATRON_INFO },
   { id: 6, items: [{ itemBarcode: 345 }], action: 'Whatever' },
 ];
 
@@ -23,7 +24,7 @@ describe('markOldPatronInfoAsSuperseded', () => {
     const newData = markOldPatronInfoAsSuperseded(data);
     expect(newData.length).toBe(data.length);
     [0, 2].forEach(i => {
-      expect(newData[i].action).toBe('Patron info added');
+      expect(newData[i].action).toBe(LOAN_ACTIONS.PATRON_INFO);
     });
     [1, 3, 4].forEach(i => {
       expect(newData[i].action).toBe('Patron info superseded');

--- a/src/CirculationLogList/markOldPatronInfoAsSuperseded.test.js
+++ b/src/CirculationLogList/markOldPatronInfoAsSuperseded.test.js
@@ -1,0 +1,32 @@
+import '@folio/stripes-acq-components/test/jest/__mock__';
+import { registerMostRecentPatronNotes, markOldPatronInfoAsSuperseded } from './markOldPatronInfoAsSuperseded';
+
+const data = [
+  { id: 1, items: [{ itemBarcode: 123 }], action: 'Patron info added' },
+  { id: 2, items: [{ itemBarcode: 123 }], action: 'Patron info added' },
+  { id: 3, items: [{ itemBarcode: 234 }], action: 'Patron info added' },
+  { id: 4, items: [{ itemBarcode: 123 }], action: 'Patron info added' },
+  { id: 5, items: [{ itemBarcode: 234 }], action: 'Patron info added' },
+  { id: 6, items: [{ itemBarcode: 345 }], action: 'Whatever' },
+];
+
+describe('markOldPatronInfoAsSuperseded', () => {
+  it('creates the mostRecentPatronNotes register', () => {
+    const register = registerMostRecentPatronNotes(data);
+    expect(Object.keys(register).length).toBe(2);
+    expect(register[123]).toBe(1);
+    expect(register[234]).toBe(3);
+    expect(register[345]).toBe(undefined);
+  });
+
+  it('calculates modified data', () => {
+    const newData = markOldPatronInfoAsSuperseded(data);
+    expect(newData.length).toBe(data.length);
+    [0, 2].forEach(i => {
+      expect(newData[i].action).toBe('Patron info added');
+    });
+    [1, 3, 4].forEach(i => {
+      expect(newData[i].action).toBe('Patron info superseded');
+    });
+  });
+});

--- a/translations/ui-circulation-log/en.json
+++ b/translations/ui-circulation-log/en.json
@@ -70,6 +70,7 @@
   "logEvent.action.Send error": "Send error",
   "logEvent.action.Patron info added": "Patron info added",
   "logEvent.action.Staff info added": "Staff info added",
+  "logEvent.action.Patron info superseded": "Patron info (SUPERSEDED)",
 
   "logEvent.actions.itemDetails": "Item details",
   "logEvent.actions.userDetails": "User details",


### PR DESCRIPTION
By definition it's impossible to modify the contents of an audit log (changing "patron info added" events to "patron into (superseded)" when a new patron info is added). So instead the UI requirement of showing older patron info as "(SUPERSEDED)" is implemented purely on the client side.