### PR TITLE
[UXPROD-3903] Support data-export-spring interface 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [UICIRCLOG-140](https://issues.folio.org/browse/UICIRCLOG-140) Disable item barcode link for virtual items, in circulation log list.
 * [UICIRCLOG-150](https://issues.folio.org/browse/UICIRCLOG-150) Define translation for ui-circulation-log permission "Circulation log: View".
 * [UICIRCLOG-148](https://issues.folio.org/browse/UICIRCLOG-148) Update "Circulation Log: All" permission with permission to download the file.
+* [UXPROD-3903](https://folio-org.atlassian.net/browse/UXPROD-3903) Support `data-export-spring` interface `2.0`
 
 ## [4.0.1](https://github.com/folio-org/ui-circulation-log/tree/v4.0.1) (2023-11-07)
 [Full Changelog](https://github.com/folio-org/ui-circulation-log/compare/v4.0.0...v4.0.1)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "circulation-logs": "1.2"
     },
     "optionalOkapiInterfaces": {
-      "data-export-spring": "1.0"
+      "data-export-spring": "1.0 2.0"
     },
     "icons": [
       {


### PR DESCRIPTION
# [Jira UXPROD-3903](https://folio-org.atlassian.net/browse/UXPROD-3903)

## Purpose
Work being done by @folio-org/bama in [mod-data-export-spring](https://github.com/folio-org/mod-data-export-spring/pull/270) and related modules necessitated a breaking change in the provided `data-export-spring` interface, bumping its version to `2.0`.  This breaking change has no impact on `ui-circulation-log`; as such, we can safely update our `package.json` to support this new version.

> [!WARNING]
> This PR **must** be merged before https://github.com/folio-org/mod-data-export-spring/pull/270, otherwise the snapshot environment will break.