### PR TITLE
UICIRCLOG-179: Reset `recordsCount` when `location.search` is empty in `useCirculationLog`. Include timezone in query of `useCirculationLogExport` (follow-up).

### DIFF
--- a/src/CirculationLogList/CirculationLogListActions/useCirculationLogExport.js
+++ b/src/CirculationLogList/CirculationLogListActions/useCirculationLogExport.js
@@ -7,7 +7,10 @@ import {
 import queryString from 'query-string';
 import { useIntl } from 'react-intl';
 
-import { useOkapiKy } from '@folio/stripes/core';
+import {
+  useOkapiKy,
+  useStripes,
+} from '@folio/stripes/core';
 import { useShowCallout, downloadBase64 } from '@folio/stripes-acq-components';
 
 import { buildLogEventsQuery } from '../utils';
@@ -62,6 +65,7 @@ export const useCirculationLogExportPolling = () => {
 export const useCirculationLogExport = (options) => {
   const location = useLocation();
   const ky = useOkapiKy();
+  const stripes = useStripes();
 
   const poll = useCirculationLogExportPolling();
 
@@ -70,7 +74,7 @@ export const useCirculationLogExport = (options) => {
       const json = {
         type: 'CIRCULATION_LOG',
         exportTypeSpecificParameters: {
-          query: buildLogEventsQuery(queryString.parse(location.search)),
+          query: buildLogEventsQuery(queryString.parse(location.search), stripes.timezone),
         },
       };
 

--- a/src/CirculationLogList/CirculationLogListActions/useCirculationLogExport.test.js
+++ b/src/CirculationLogList/CirculationLogListActions/useCirculationLogExport.test.js
@@ -1,0 +1,59 @@
+import { act } from 'react';
+import {
+  QueryClient,
+  QueryClientProvider,
+} from 'react-query';
+
+import { useOkapiKy } from '@folio/stripes/core';
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useCirculationLogExport } from './useCirculationLogExport';
+import { buildLogEventsQuery } from '../utils';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  buildLogEventsQuery: jest.fn(),
+}));
+
+useOkapiKy.mockReturnValue({
+  get: jest.fn().mockReturnValue({
+    json: jest.fn().mockResolvedValue({
+      id: '123',
+      status: 'SUCCESSFUL',
+      fileNames: ['export.csv'],
+    }),
+  }),
+  post: jest.fn().mockReturnValue({
+    json: jest.fn().mockResolvedValue({ id: '123' }),
+  }),
+});
+
+const queryClient = new QueryClient();
+
+const timezone = 'UTC';
+const mockOnSuccess = jest.fn();
+
+const wrapper = ({ children }) => (
+  <QueryClientProvider client={queryClient}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe('useCirculationLogExport', () => {
+  describe('when buildLogEventsQuery is called', () => {
+    it('should pass timezone', async () => {
+      const { result } = renderHook(() => useCirculationLogExport({
+        onSuccess: mockOnSuccess,
+      }), { wrapper });
+
+      await act(() => result.current.requestExport());
+
+      expect(buildLogEventsQuery).toHaveBeenCalledWith(expect.any(Object), timezone);
+    });
+  });
+});

--- a/src/hooks/useCirculationLog.js
+++ b/src/hooks/useCirculationLog.js
@@ -51,6 +51,9 @@ export const useCirculationLog = (isLoadingRightAway, queryLoadRecords, loadReco
   }, [isLoadingRightAway, isLoading, loadRecordsCB, location.search, queryLoadRecords]);
 
   const refreshList = useCallback(() => {
+    if (!location.search) {
+      setRecordsCount(0);
+    }
     setRecords([]);
     loadRecords(0);
   }, [loadRecords]);

--- a/src/hooks/useCirculationLog.js
+++ b/src/hooks/useCirculationLog.js
@@ -56,7 +56,7 @@ export const useCirculationLog = (isLoadingRightAway, queryLoadRecords, loadReco
     }
     setRecords([]);
     loadRecords(0);
-  }, [loadRecords]);
+  }, [loadRecords, location.search]);
 
   useEffect(
     () => {

--- a/src/hooks/useCirlcuationLog.test.js
+++ b/src/hooks/useCirlcuationLog.test.js
@@ -1,3 +1,4 @@
+import { act } from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { useLocation } from 'react-router-dom';
 
@@ -53,6 +54,30 @@ describe('useCirculationLog', () => {
     expect(result.current.records).toEqual({
       totalRecords: 100,
       logRecords: { id: 1 },
+    });
+  });
+
+  describe('when location.search is empty', () => {
+    it('should reset recordsCount', async () => {
+      useLocation.mockReturnValue({ search: '?limit=100&offset=0&userBarcode=1' });
+
+      const { result, rerender } = renderHook(
+        () => useCirculationLog(false,
+          jest.fn().mockResolvedValue(),
+          null,
+          {
+            limit: 100,
+            offset: 0,
+          }),
+      );
+
+      await act(async () => !result.current.isLoading);
+
+      useLocation.mockReturnValue({ search: '' });
+      rerender();
+
+      await act(async () => !result.current.isLoading);
+      expect(result.current.recordsCount).toBe(0);
     });
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
1. Do not display the number of records in the results after the reset button is hit.
2. The number of records returned for the results pane should match the exported one when using the date filter.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->

## Approach
1. When `location.search` is empty, set `recordsCount` to 0.
2. The query to export records must take into account the timezone, as is already done in the query to retrieve records.

## Issues
https://folio-org.atlassian.net/browse/UICIRCLOG-179





## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
