### PR TITLE
UICIRCLOG-185: Reset offset when performing search from 2+ page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add loan-action filter options In Use and Held. Refs UICIRCLOG-181.
 * Migrate jest to use `@folio/jest-config-stripes`. Refs UICIRCLOG-182.
 * Add `stripes-core.settings.read` permission to app permissions. Refs UICIRCLOG-190.
+* Reset offset when applying new search filters. Refs UICIRCLOG-185.
 
 ## 6.0.2 (https://github.com/folio-org/ui-circulation-log/tree/v6.0.2) (2025-11-04)
 [Full Changelog](https://github.com/folio-org/ui-circulation-log/compare/v6.0.1...v6.0.2)

--- a/src/hooks/useCirculationLog.js
+++ b/src/hooks/useCirculationLog.js
@@ -24,7 +24,7 @@ export const useCirculationLog = (isLoadingRightAway, queryLoadRecords, loadReco
     // is not visible to other effects running in the same render cycle. Using queryParams
     // (derived synchronously from location.search) ensures we always see the current URL
     // value and avoid firing API calls with a stale offset when filters change.
-    offset: parseInt(queryParams.offset || '0', 10),
+    offset: Number.parseInt(queryParams.offset || '0', 10),
   };
 
   const loadRecords = useCallback(offset => {

--- a/src/hooks/useCirculationLog.js
+++ b/src/hooks/useCirculationLog.js
@@ -19,7 +19,12 @@ export const useCirculationLog = (isLoadingRightAway, queryLoadRecords, loadReco
   const defaultSearchParams = {
     queryParams,
     limit: pagination.limit,
-    offset: pagination.offset,
+    // Read offset directly from the URL rather than from pagination.offset (React state).
+    // usePagination resets its offset state to 0 inside a useEffect, but that state update
+    // is not visible to other effects running in the same render cycle. Using queryParams
+    // (derived synchronously from location.search) ensures we always see the current URL
+    // value and avoid firing API calls with a stale offset when filters change.
+    offset: parseInt(queryParams.offset || '0', 10),
   };
 
   const loadRecords = useCallback(offset => {

--- a/src/hooks/useCirlcuationLog.test.js
+++ b/src/hooks/useCirlcuationLog.test.js
@@ -82,4 +82,38 @@ describe('useCirculationLog', () => {
       expect(result.current.recordsCount).toBe(0);
     });
   });
+
+  describe('when offset is not present in location.search', () => {
+    it('should call API with offset 0 regardless of pagination.offset prop', async () => {
+      useLocation.mockReturnValue({ search: '?userBarcode=test' });
+      const queryLoadRecords = jest.fn().mockResolvedValue(undefined);
+
+      renderHook(() => useCirculationLog(
+        true,
+        queryLoadRecords,
+        null,
+        { limit: 100, offset: 100 },
+      ));
+
+      await waitFor(() => expect(queryLoadRecords).toHaveBeenCalled());
+      expect(queryLoadRecords).toHaveBeenLastCalledWith(0);
+    });
+  });
+
+  describe('when offset is present in location.search', () => {
+    it('should call API with the offset from URL', async () => {
+      useLocation.mockReturnValue({ search: '?userBarcode=test&offset=100' });
+      const queryLoadRecords = jest.fn().mockResolvedValue(undefined);
+
+      renderHook(() => useCirculationLog(
+        true,
+        queryLoadRecords,
+        null,
+        { limit: 100, offset: 0 },
+      ));
+
+      await waitFor(() => expect(queryLoadRecords).toHaveBeenCalled());
+      expect(queryLoadRecords).toHaveBeenLastCalledWith(100);
+    });
+  });
 });

--- a/src/hooks/useLocationFilters.js
+++ b/src/hooks/useLocationFilters.js
@@ -16,7 +16,11 @@ export const useLocationFilters = ({ history, location }) => {
 
       history.push({
         pathname: '',
-        search: `${buildSearch(filtersToMerge, location.search)}`,
+        // Reset offset when applying new filters so usePagination never sees a stale
+        // offset in the URL. Without this, buildSearch would preserve the old offset
+        // (e.g. offset=100 from page 2), and useCirculationLog's effect would fire
+        // against that intermediate URL before usePagination resets it to 0.
+        search: buildSearch({ ...filtersToMerge, offset: undefined }, location.search),
       });
 
       return newFilters;

--- a/src/hooks/useLocationFilters.test.js
+++ b/src/hooks/useLocationFilters.test.js
@@ -1,0 +1,56 @@
+import { act } from 'react';
+import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
+
+import { useLocationFilters } from './useLocationFilters';
+
+describe('useLocationFilters', () => {
+  const mockHistory = { push: jest.fn() };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('applyFilters', () => {
+    describe('when offset is present in location.search', () => {
+      it('should strip offset from the resulting URL', () => {
+        const mockLocation = { search: '?offset=100&limit=100&userBarcode=old' };
+        const { result } = renderHook(() => useLocationFilters({ history: mockHistory, location: mockLocation }));
+
+        act(() => {
+          result.current.applyFilters({ userBarcode: 'new' });
+        });
+
+        const pushedSearch = mockHistory.push.mock.calls[0][0].search;
+        expect(pushedSearch).not.toMatch(/offset=100/);
+      });
+    });
+
+    describe('when offset is not present in location.search', () => {
+      it('should push new filters without adding offset', () => {
+        const mockLocation = { search: '?limit=100&userBarcode=old' };
+        const { result } = renderHook(() => useLocationFilters({ history: mockHistory, location: mockLocation }));
+
+        act(() => {
+          result.current.applyFilters({ userBarcode: 'new' });
+        });
+
+        const pushedSearch = mockHistory.push.mock.calls[0][0].search;
+        expect(pushedSearch).toMatch(/userBarcode=new/);
+        expect(pushedSearch).not.toMatch(/offset=/);
+      });
+    });
+  });
+
+  describe('resetFilters', () => {
+    it('should push empty search', () => {
+      const mockLocation = { search: '?offset=100&userBarcode=test' };
+      const { result } = renderHook(() => useLocationFilters({ history: mockHistory, location: mockLocation }));
+
+      act(() => {
+        result.current.resetFilters();
+      });
+
+      expect(mockHistory.push).toHaveBeenCalledWith({ pathname: '', search: '' });
+    });
+  });
+});


### PR DESCRIPTION
## Purpose

When a user navigates to page 2+ and then changes search filters, the API was called with the stale `offset=100` instead of `0`, silently returning the wrong set of records. No error is shown — results look valid but are the wrong page of data.

## Approach

The root cause is a React effect ordering race condition. Both `usePagination` and `useCirculationLog` respond to `location.search` changes via `useEffect`. When filters change, `usePagination` resets its offset state to 0 in its own effect, but that state update is not visible to `useCirculationLog`'s effect running in the same render cycle.

Two fixes applied together:

1. **`useLocationFilters.applyFilters`** — passes `offset: undefined` to `buildSearch` so the stale offset is stripped from the URL immediately when new filters are applied, eliminating the intermediate `offset=100&newFilter` URL state.

2. **`useCirculationLog`** — reads offset from `queryParams` (derived synchronously from `location.search`) instead of `pagination.offset` (React state that can be stale during effects).

Both changes are covered by unit tests.

## Issues

[UICIRCLOG-185](https://folio-org.atlassian.net/browse/UICIRCLOG-185)